### PR TITLE
Better Search and Token Lookup

### DIFF
--- a/snap_bot/database/card.py
+++ b/snap_bot/database/card.py
@@ -1,10 +1,14 @@
+import json
+
 from . import Entry
 
 class Card(Entry):
-    def __init__(self, name: str, cost: int, power: int, ability: str, released: bool, url: str):
-        super().__init__(name, ability, released, url)
+    def __init__(self, def_id: str, name: str, cost: int, power: int, ability: str, released: bool, url: str, is_token: bool, connected_cards):
+        super().__init__(def_id, name, ability, released, url)
         self.cost = cost
         self.power = power
+        self.is_token = is_token
+        self.connected_cards = json.loads(connected_cards)
         self.formatted_ability = ''
 
     def __str__(self):
@@ -32,4 +36,6 @@ class Card(Entry):
                self.power == other.power and \
                self.ability == other.ability and \
                self.released == other.released and \
+               self.is_token == other.is_token and \
+               self.connected_cards == other.connected_cards and \
                self.url == other.url

--- a/snap_bot/database/entry.py
+++ b/snap_bot/database/entry.py
@@ -3,7 +3,8 @@ import re
 from . import Lookup
 
 class Entry(Lookup):
-    def __init__(self, name, ability, released, url):
+    def __init__(self, def_id: str, name: str, ability: str, released: bool, url: str):
+        self.def_id = def_id
         self.name = name
         self.ability = ability
         self.released = released

--- a/snap_bot/database/location.py
+++ b/snap_bot/database/location.py
@@ -1,8 +1,8 @@
 from . import Entry
 
 class Location(Entry):
-    def __init__(self, name:str, ability:str, rarity:str, released:bool, url:str):
-        super().__init__(name, ability, released, url)
+    def __init__(self, def_id: str, name:str, ability:str, rarity:str, released:bool, url:str):
+        super().__init__(def_id, name, ability, released, url)
         self.rarity = rarity
     
     def __str__(self):

--- a/snap_bot/main.py
+++ b/snap_bot/main.py
@@ -223,6 +223,14 @@ if __name__ == '__main__':
                 # Resolve all tokens to their base cards if possible
                 unique_cards = utils.resolve_tokens_to_base(database, unique_cards)
                 
+                # Resolving tokens to cards could add duplicate cards, since a
+                # card like Snowguard or Nico call their summon cards the same
+                # as the base card. This could result in duplicating cards and
+                # causing a much larger output than expected. Removing
+                # duplicates here before we expand back into tokens will resolve
+                # this issue.
+                unique_cards = utils.remove_duplicate_cards(unique_cards)
+
                 # Now reverse the above and resolve all tokens from all base cards
                 unique_cards = utils.insert_tokens_from_cards(database, unique_cards)
 

--- a/snap_bot/main.py
+++ b/snap_bot/main.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 
-from database import Database
+from database import Database, Card
 from reddit_connect import RedditConnect
 from comments import CommentParser
 import utils
@@ -176,6 +176,28 @@ if __name__ == '__main__':
     last_database_update = datetime.datetime.now()
     logging.info('Next DB update in ' + str(db_update_timeout) + 's')
 
+    cards = database.search('soul stone')
+    for card in cards:
+        print(card)
+    
+    cards = database.search('demon')
+    for card in cards:
+        print(card)
+    
+    cards = database.search('Mjolnir')
+    for card in cards:
+        print(card)
+    
+    cards = database.search('Stormbreaker')
+    for card in cards:
+        print(card)
+    
+    cards = database.search('Beta Ray Bill')
+    for card in cards:
+        print(card)
+
+    sys.exit(1)
+
     logging.info('Establishing Reddit connection (' + subreddit + ')')
     if len(config_file) > 0:
         logging.info('Using Reddit config file')
@@ -219,6 +241,12 @@ if __name__ == '__main__':
                     for item in database.search(name):
                         matched_cards.append(item)
                 unique_cards = utils.remove_duplicate_cards(matched_cards)
+
+                # Resolve all tokens to their base cards if possible
+                unique_cards = utils.resolve_tokens_to_base(database, unique_cards)
+                
+                # Now reverse the above and resolve all tokens from all base cards
+                unique_cards = utils.insert_tokens_from_cards(database, unique_cards)
 
                 # Combine all of the cards from above together into a single
                 # output message

--- a/snap_bot/main.py
+++ b/snap_bot/main.py
@@ -176,28 +176,6 @@ if __name__ == '__main__':
     last_database_update = datetime.datetime.now()
     logging.info('Next DB update in ' + str(db_update_timeout) + 's')
 
-    cards = database.search('soul stone')
-    for card in cards:
-        print(card)
-    
-    cards = database.search('demon')
-    for card in cards:
-        print(card)
-    
-    cards = database.search('Mjolnir')
-    for card in cards:
-        print(card)
-    
-    cards = database.search('Stormbreaker')
-    for card in cards:
-        print(card)
-    
-    cards = database.search('Beta Ray Bill')
-    for card in cards:
-        print(card)
-
-    sys.exit(1)
-
     logging.info('Establishing Reddit connection (' + subreddit + ')')
     if len(config_file) > 0:
         logging.info('Using Reddit config file')

--- a/snap_bot/utils.py
+++ b/snap_bot/utils.py
@@ -15,12 +15,28 @@ def resolve_tokens_to_base(database, cards):
     """
     result = [x for x in cards]
     for i in range(0, len(result)):
-        if isinstance(result[i], Card) and result[i].is_token and len(result[i].connected_cards) > 0:
-            for j in range(0, len(result[i].connected_cards)):
-                card = database.search_defid(result[i].connected_cards[j])
-                if card is not None and not card.is_token:
-                    result[i] = card
-                    break
+        if isinstance(result[i], Card) and result[i].is_token:
+            replaced = False
+            if len(result[i].connected_cards) > 0:
+                for j in range(0, len(result[i].connected_cards)):
+                    card = database.search_defid(result[i].connected_cards[j])
+                    if card is not None and not card.is_token:
+                        result[i] = card
+                        replaced = True
+                        break
+
+            # Unfortuantely, there is an issue with doing a lookup like the
+            # above for Nico specifically. She links to her spells BUT her spells
+            # do not link back to her. So if we do not find a match from the
+            # above, we will do this the "hard way" and search each card
+            # looking for a match back to the summon
+            if not replaced:
+                for card in database.cards:
+                    if result[i].def_id in card.connected_cards:
+                        result[i] = card
+                        replaced = True
+                        break
+
     return result
 
 def insert_tokens_from_cards(database, cards):

--- a/snap_bot/utils.py
+++ b/snap_bot/utils.py
@@ -1,6 +1,39 @@
 from database import Card
 
 def remove_duplicate_cards(cards):
+    """
+    Search through the list of cards and remove all duplicate values
+    """
     unique_cards = []
     [unique_cards.append(x) for x in cards if x not in unique_cards]
     return unique_cards
+
+def resolve_tokens_to_base(database, cards):
+    """
+    Search through the list of cards and resolve all Tokens to their Base card
+    based on the connected cards field
+    """
+    result = [x for x in cards]
+    for i in range(0, len(result)):
+        if isinstance(result[i], Card) and result[i].is_token and len(result[i].connected_cards) > 0:
+            for j in range(0, len(result[i].connected_cards)):
+                card = database.search_defid(result[i].connected_cards[j])
+                if card is not None and not card.is_token:
+                    result[i] = card
+                    break
+    return result
+
+def insert_tokens_from_cards(database, cards):
+    """
+    Search through the list of cards and find all cards that have tokens, then
+    insert their tokens into the array
+    """
+    final_cards = []
+    for i in range(0, len(cards)):
+        final_cards.append(cards[i])
+        if isinstance(cards[i], Card) and not cards[i].is_token and len(cards[i].connected_cards) > 0:
+            for j in range(0, len(cards[i].connected_cards)):
+                card = database.search_defid(cards[i].connected_cards[j])
+                if card is not None:
+                    final_cards.append(card)
+    return final_cards

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -11,7 +11,7 @@ class TestCommentParser(unittest.TestCase):
         Test that a card string output is the exact expected string output for
         displaying
         """
-        card = Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine')
+        card = Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]')
         card.format_ability_from_html()
 
         card_text = str(card)
@@ -24,7 +24,7 @@ class TestCommentParser(unittest.TestCase):
         Test that a card string output with HTML contents is the exact string
         output for displaying
         """
-        card = Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru')
+        card = Card('NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru', False, '[]')
         card.format_ability_from_html()
 
         card_text = str(card)
@@ -36,7 +36,7 @@ class TestCommentParser(unittest.TestCase):
         """
         Test that a card marked as unreleased includes the appropriate tag
         """
-        card = Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', False, 'https://marvelsnap.pro/cards/wolverine')
+        card = Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', False, 'https://marvelsnap.pro/cards/wolverine', False, '[]')
         card.format_ability_from_html()
 
         card_text = str(card)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -187,7 +187,32 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(len(expected_result), len(result))
         for i in range(0, len(result)):
             self.assertEqual(expected_result[i], result[i])
+    
+    def test_match_nico_duplication(self):
+        """
+        Verify that a card with many summons (Nico SPECIFICALLY) can correctly
+        pull from the base card search, each of the summons.
+        """
+        cards = self.database.search('nico')
+        cards = utils.remove_duplicate_cards(cards)
+        cards = utils.resolve_tokens_to_base(self.database, cards)
+        cards = utils.remove_duplicate_cards(cards)
+        results = utils.insert_tokens_from_cards(self.database, cards)
+
+        expected_results = [
+            Card('NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru', False, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell02NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, it becomes a Demon.', True, 'https://marvelsnap.pro/cards/spell01nicominoru', True, '["Demon", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell03NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, destroy it to draw two cards.', True, 'https://marvelsnap.pro/cards/spell02nicominoru', True, '["Spell01NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell04NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, move it one location to the right.', True, 'https://marvelsnap.pro/cards/spell03nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell05NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, give it +2 Power.', True, 'https://marvelsnap.pro/cards/spell04nicominoru', True, 	'["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell06NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, replace that card\'s location.', True, 'https://marvelsnap.pro/cards/spell05nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell07NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, add a copy of it to your hand.', True, 'https://marvelsnap.pro/cards/spell06nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell08NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru"]')
+            ]
         
+        self.assertEqual(len(expected_results), len(results))
+        for i in range(0, len(results)):
+            self.assertEqual(expected_results[i], results[i])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,6 +6,7 @@ sys.path.append('snap_bot')
 from database import Database
 from database import Card
 from database import Location
+import utils
 
 class TestDatabase(unittest.TestCase):
     @classmethod
@@ -20,7 +21,7 @@ class TestDatabase(unittest.TestCase):
 
     def test_exact_search(self):
         result = self.database.search('wolverine')
-        expected_results = [Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine')]
+        expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]')]
  
         self.assertEqual(len(expected_results), len(result))
         for i in range(0, len(result)):
@@ -32,7 +33,7 @@ class TestDatabase(unittest.TestCase):
         of the Database class, this should be acceptable
         """
         result = self.database.search('wolerine')
-        expected_results = [Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine')]
+        expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]')]
  
         self.assertEqual(len(expected_results), len(result))
         for i in range(0, len(result)):
@@ -44,7 +45,7 @@ class TestDatabase(unittest.TestCase):
         of the Database class, this should be acceptable
         """
         result = self.database.search('olerine')
-        expected_results = [Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine')]
+        expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]')]
  
         self.assertEqual(len(expected_results), len(result))
         for i in range(0, len(result)):
@@ -56,7 +57,7 @@ class TestDatabase(unittest.TestCase):
         of the Database class, this should fail
         """
         result = self.database.search('lerine')
-        expected_results = [Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine')]
+        expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]')]
 
         self.assertNotEqual(len(expected_results), len(result))
 
@@ -66,14 +67,14 @@ class TestDatabase(unittest.TestCase):
         """
         result = self.database.search('Nico Minoru')
         expected_results = [
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, it becomes a Demon.', True, 'https://marvelsnap.pro/cards/spell01nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, destroy it to draw two cards.', True, 'https://marvelsnap.pro/cards/spell02nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, move it one location to the right.', True, 'https://marvelsnap.pro/cards/spell03nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, give it +2 Power.', True, 'https://marvelsnap.pro/cards/spell04nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, replace that card\'s location.', True, 'https://marvelsnap.pro/cards/spell05nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, add a copy of it to your hand.', True, 'https://marvelsnap.pro/cards/spell06nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru')
+            Card('NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru', False, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell02NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, it becomes a Demon.', True, 'https://marvelsnap.pro/cards/spell01nicominoru', True, '["Demon", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell03NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, destroy it to draw two cards.', True, 'https://marvelsnap.pro/cards/spell02nicominoru', True, '["Spell01NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell04NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, move it one location to the right.', True, 'https://marvelsnap.pro/cards/spell03nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell05NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, give it +2 Power.', True, 'https://marvelsnap.pro/cards/spell04nicominoru', True, 	'["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell06NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, replace that card\'s location.', True, 'https://marvelsnap.pro/cards/spell05nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell07NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, add a copy of it to your hand.', True, 'https://marvelsnap.pro/cards/spell06nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell08NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru"]')
             ]
 
         self.assertEqual(len(expected_results), len(result))
@@ -87,14 +88,14 @@ class TestDatabase(unittest.TestCase):
         """
         result = self.database.search('ico Minoru')
         expected_results = [
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, it becomes a Demon.', True, 'https://marvelsnap.pro/cards/spell01nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, destroy it to draw two cards.', True, 'https://marvelsnap.pro/cards/spell02nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, move it one location to the right.', True, 'https://marvelsnap.pro/cards/spell03nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, give it +2 Power.', True, 'https://marvelsnap.pro/cards/spell04nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, replace that card\'s location.', True, 'https://marvelsnap.pro/cards/spell05nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, add a copy of it to your hand.', True, 'https://marvelsnap.pro/cards/spell06nicominoru'),
-            Card('Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru')
+            Card('NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, cast a spell. <i>(The spell changes each turn.)</i>', True, 'https://marvelsnap.pro/cards/nicominoru', False, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell02NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, it becomes a Demon.', True, 'https://marvelsnap.pro/cards/spell01nicominoru', True, '["Demon", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell03NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, destroy it to draw two cards.', True, 'https://marvelsnap.pro/cards/spell02nicominoru', True, '["Spell01NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell04NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, move it one location to the right.', True, 'https://marvelsnap.pro/cards/spell03nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell05NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, give it +2 Power.', True, 'https://marvelsnap.pro/cards/spell04nicominoru', True, 	'["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell06NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, replace that card\'s location.', True, 'https://marvelsnap.pro/cards/spell05nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell06NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell07NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, add a copy of it to your hand.', True, 'https://marvelsnap.pro/cards/spell06nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell07NicoMinoru"]'),
+            Card('Spell08NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru"]')
             ]
 
         self.assertEqual(len(expected_results), len(result))
@@ -106,7 +107,7 @@ class TestDatabase(unittest.TestCase):
         Test to ensure that a location may be searched
         """
         result = self.database.search('Altar of Death')
-        expected_results = [Location('Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', True, 'https://marvelsnap.pro/cards/altarofdeath')]
+        expected_results = [Location('AltarOfDeath', 'Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', True, 'https://marvelsnap.pro/cards/altarofdeath')]
 
         self.assertEqual(len(expected_results), len(result))
         for i in range(0, len(result)):
@@ -118,7 +119,7 @@ class TestDatabase(unittest.TestCase):
         do not need to supply the full name with spaces for it to be found
         """
         result = self.database.search('hope')
-        expected_results = [Card('Hope Summers', '3', '3', 'After you play a card here, you get +2 Energy next turn.', False, 'https://marvelsnap.pro/cards/hopesummers')]
+        expected_results = [Card('HopeSummers', 'Hope Summers', '3', '3', 'After you play a card here, you get +2 Energy next turn.', False, 'https://marvelsnap.pro/cards/hopesummers', False, '[]')]
         
         self.assertEqual(len(expected_results), len(result))
         for i in range(0, len(result)):
@@ -143,11 +144,50 @@ class TestDatabase(unittest.TestCase):
         a partial of the name (e.g. "Mobius")
         """
         result = self.database.search('Mobius')
-        expected_results = [Card('Mobius M. Mobius', '3', '3', '<b>Ongoing:</b> Your Costs can\'t be increased. Your opponent\'s Costs can\'t be reduced.', True, 'https://marvelsnap.pro/cards/mobiusmmobius')]
+        expected_results = [Card('MobiusMMobius', 'Mobius M. Mobius', '3', '3', '<b>Ongoing:</b> Your Costs can\'t be increased. Your opponent\'s Costs can\'t be reduced.', True, 'https://marvelsnap.pro/cards/mobiusmmobius', False, '[]')]
 
         self.assertEqual(len(expected_results), len(result))
         for i in range(0, len(result)):
             self.assertEqual(expected_results[i], result[i])
+
+    def test_resolve_tokens(self):
+        """
+        Test that the resolve_tokens_to_base() function successfully resolves
+        an array of tokens to the base cards that can summon them
+        """
+        cards = self.database.search('Soul Stone')
+        result = utils.resolve_tokens_to_base(self.database, cards)
+
+        expected_result = [
+            Card('Thanos', 'Thanos', '6', '10', 'At the start of the game, shuffle the six Infinity Stones into your deck.', True, 'https://marvelsnap.pro/cards/thanos', False, '["SpaceStone", "RealityStone", "TimeStone", "MindStone", "PowerStone", "SoulStone"]')
+        ]
+
+        self.assertEqual(len(expected_result), len(result))
+        for i in range(0, len(result)):
+            self.assertEqual(expected_result[i], result[i])
+
+    def test_insert_tokens(self):
+        """
+        Test that we can go from a base card to have the tokens added to the
+        array of cards.
+        """
+        cards = self.database.search('Thanos')
+        result = utils.insert_tokens_from_cards(self.database, cards)
+
+        expected_result = [
+            Card('Thanos', 'Thanos', '6', '10', 'At the start of the game, shuffle the six Infinity Stones into your deck.', True, 'https://marvelsnap.pro/cards/thanos', False, '["SpaceStone", "RealityStone", "TimeStone", "MindStone", "PowerStone", "SoulStone"]'),
+            Card('SpaceStone', 'Space Stone', '1', '1', '<b>On Reveal:</b> Next turn, you can move one card to this location. Draw a card.', True, 'https://marvelsnap.pro/cards/spacestone', True, '["Thanos"]'),
+            Card('RealityStone', 'Reality Stone', '1', '1', '<b>On Reveal:</b> Transform this location into a new one. Draw a card.', True, 'https://marvelsnap.pro/cards/realitystone', True, '["Thanos"]'),
+            Card('TimeStone', 'Time Stone', '1', '1', '<b>On Reveal:</b> Draw a card. Next turn, you get +1 Energy.', True, 'https://marvelsnap.pro/cards/timestone', True, '["Thanos"]'),
+            Card('MindStone', 'Mind Stone', '1', '1', '<b>On Reveal:</b> Draw 2 1-Cost cards from your deck.', True, 'https://marvelsnap.pro/cards/mindstone', True, '["Thanos"]'),
+            Card('PowerStone', 'Power Stone', '1', '3', '<b>Ongoing:</b> If you\'ve played all 6 stones, Thanos has +10 Power. <i>(wherever he is)</i>', True, 'https://marvelsnap.pro/cards/powerstone', True, '["Thanos"]'),
+            Card('SoulStone', 'Soul Stone', '1', '1', '<b>Ongoing:</b> Enemy cards here have -1 Power.', True, 'https://marvelsnap.pro/cards/soulstone', True, '["Thanos"]')
+        ]
+
+        self.assertEqual(len(expected_result), len(result))
+        for i in range(0, len(result)):
+            self.assertEqual(expected_result[i], result[i])
+        
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -10,7 +10,7 @@ class TestCommentParser(unittest.TestCase):
         """
         Test that a location generates the exact expected output text
         """
-        location = Location('Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', True, 'https://marvelsnap.pro/cards/altarofdeath')
+        location = Location('AltarOfDeath', 'Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', True, 'https://marvelsnap.pro/cards/altarofdeath')
         location_text = str(location)
         
         expected_location_text = r'**\[[Altar of Death](https://marvelsnap.pro/cards/altarofdeath)\]** **Location:** Rarity Rare' + '  \n' + r'**Description:** After you play a card here, destroy it to get +2 Energy next turn.' + '\n\n'
@@ -21,7 +21,7 @@ class TestCommentParser(unittest.TestCase):
         """
         Test that a card that is unreleased includes the appropriate tag
         """
-        location = Location('Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', False, 'https://marvelsnap.pro/cards/altarofdeath')
+        location = Location('AltarOfDeath', 'Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', False, 'https://marvelsnap.pro/cards/altarofdeath')
         location_text = str(location)
         
         expected_location_text = r'**\[[Altar of Death](https://marvelsnap.pro/cards/altarofdeath)\]** (Unreleased) **Location:** Rarity Rare' + '  \n' + r'**Description:** After you play a card here, destroy it to get +2 Energy next turn.' + '\n\n'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,27 +13,27 @@ class TestCommentParser(unittest.TestCase):
         duplicates have been removed from the list of cards.
         """
         cards = [
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine'),
-            Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine'),
-            Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine'),
-            Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine'),
-            Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]'),
+            Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]'),
+            Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]'),
+            Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]'),
+            Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]')
         ]
 
         result = utils.remove_duplicate_cards(cards)
         expected_result = [
-            Card('Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin'),
-            Card('Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine')
+            Card('Odin', 'Odin', '6', '8', 'On Reveal: Activate the On Reveal abilities of your other cards here.', True, 'https://marvelsnap.pro/cards/odin', False, '[]'),
+            Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]')
         ]
 
         self.assertEqual(len(expected_result), len(result))


### PR DESCRIPTION
This revamps the way tokens are searched for. It might be slightly less intuitive, but I feel like it provides an overall better user experience.

When someone searches for a base card like `[[thanos]]`, this will check to see what cards may be created by that card (e.g. Soul Stone, Time Stone, etc.) and it will automatically pull those in, producing an output that includes both the base card and the added tokens.

In addition to that, if someone searches directly for a token like `[[Soul Stone]]`, this will detect that it is a token and will replace the token with the base card (e.g. `[[Thanos]]`), then it will resolve like normal, which will pull in all associated cards.