### PR TITLE
Fix High Evolutionary Cards

### DIFF
--- a/snap_bot/database/card.py
+++ b/snap_bot/database/card.py
@@ -11,6 +11,28 @@ class Card(Entry):
         self.connected_cards = json.loads(connected_cards)
         self.formatted_ability = ''
         self.summoned = summoned
+        self.searchable = True
+
+    def to_constructor_string(self):
+        """
+        Useful for debugging or writing test cases, this outputs a card in a
+        format that may be copied and pasted to create a constructor for it.
+        It's not perfect as it doesn't account for spaces in the JSON and quotes
+        in the abilities, but overall it's fine for what I need.
+        """
+        template = r"Card('{def_id}', '{name}', '{cost}', '{power}', '{ability}', {released}, {url}, {is_token}, '{connected_cards}', {summoned})"
+
+        return template.format(
+            def_id = self.def_id,
+            name = self.name,
+            cost = self.cost,
+            power = self.power,
+            ability = self.ability,
+            released = ('True' if self.released else 'False'),
+            url = ("'" + self.url + "'" if self.url is not None else 'None'),
+            is_token = ('True' if self.is_token else 'False'),
+            connected_cards = json.dumps(self.connected_cards),
+            summoned = ('True' if self.summoned else 'False'))
 
     def __str__(self):
         """
@@ -20,9 +42,14 @@ class Card(Entry):
         template = ''
 
         if self.summoned:
-            template = r'* **\[[{name}]({url})\]** {status}**Cost:** {cost} **Power:** {power}  \n**Ability:** {ability}\n\n'
+            template += r'* '
+        
+        if self.url is not None:
+            template += r'**\[[{name}]({url})\]** '
         else:
-            template = r'**\[[{name}]({url})\]** {status}**Cost:** {cost} **Power:** {power}  \n**Ability:** {ability}\n\n'
+            template += r'**\[{name}\]** '
+
+        template += r'{status}**Cost:** {cost} **Power:** {power}  \n**Ability:** {ability}\n\n'
         template = template.replace(r'\n', '\n')
 
         return template.format(

--- a/snap_bot/database/database.py
+++ b/snap_bot/database/database.py
@@ -64,6 +64,24 @@ class Database:
             card.name = 'Snowguard Bear'
         elif card.def_id == 'SnowguardHawk':
             card.name = 'Snowguard Hawk'
+    
+    def update_card_url(self, card):
+        """
+        Update or remove the URL if it is a card we know has a non-funcitoning URL.
+        It would technically be possible to ping each URL and verify that they
+        are valid, but I do not want to put any unneeded stress on the server
+        I'm obtaining the card lookup information from. So instead, I'm just
+        going to hardcode a list of cards to remove the URL from.
+        """
+        
+        if card.def_id == 'EvolvedAbomination' or \
+           card.def_id == 'EvolvedCyclops' or \
+           card.def_id == 'EvolvedHulk' or \
+           card.def_id == 'EvolvedMistyKnight' or \
+           card.def_id == 'EvolvedShocker' or \
+           card.def_id == 'EvolvedTheThing' or \
+           card.def_id == 'EvolvedWasp':
+            card.url = None
 
     def update_card_database_marvelsnappro(self):
         """
@@ -111,6 +129,7 @@ class Database:
                     summoned = False))
                 self.update_card_searchability(self.summons[-1])
                 self.update_card_name(self.summons[-1])
+                self.update_card_url(self.summons[-1])
                 self.summons[-1].format_ability_from_html()
             else:
                 self.cards.append(Card(
@@ -126,6 +145,7 @@ class Database:
                     summoned = False))
                 self.update_card_searchability(self.cards[-1])
                 self.update_card_name(self.cards[-1])
+                self.update_card_url(self.cards[-1])
                 self.cards[-1].format_ability_from_html()
 
         data = self.download_url(api_location_url)

--- a/snap_bot/database/entry.py
+++ b/snap_bot/database/entry.py
@@ -51,4 +51,5 @@ class Entry(Lookup):
         For use when using marvelsnap.pro as the source, converting the output
         into a pretty print output for display on Reddit
         """
-        self.formatted_ability = self.ability.replace('<b>', '**').replace('</b>', '**').replace('<i>', '*').replace('</i>', '*')
+        self.formatted_ability = self.ability.replace('<b>', '**').replace('</b>', '**').replace('<i>', '*').replace('</i>', '*').replace('</color>', '')
+        self.formatted_ability = re.sub(r'<color=[^>]+>', '', self.formatted_ability)

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -55,6 +55,18 @@ class TestCommentParser(unittest.TestCase):
         expected_card_text = r'* **\[[Mind Stone](https://marvelsnap.pro/cards/mindstone)\]** **Cost:** 1 **Power:** 1' + '  \n' + r'**Ability:** **On Reveal:** Draw 2 1-Cost cards from your deck.' + '\n\n'
 
         self.assertEqual(expected_card_text, card_text)
+    
+    def test_card_text_evoled(self):
+        """
+        Test that an evolved card does not have the color HTML text
+        """
+        card = Card('Hulk', 'Hulk', '6', '12', '<color=#fad728>When you end a turn with unspent Energy, +2 Power. <i>(if in hand or in play)</i></color>', True, None, False, '[]', True)
+        card.format_ability_from_html()
+
+        card_text = str(card)
+        expected_card_text = r'* **\[Hulk\]** **Cost:** 6 **Power:** 12' + '  \n' + r'**Ability:** When you end a turn with unspent Energy, +2 Power. *(if in hand or in play)*' + '\n\n'
+
+        self.assertEqual(expected_card_text, card_text)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -23,9 +23,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('wolverine')
         expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]', False)]
  
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
     
     def test_fuzzy_search_1(self):
         """
@@ -35,9 +33,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('wolerine')
         expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]', False)]
  
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_fuzzy_search_2(self):
         """
@@ -47,9 +43,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('olerine')
         expected_results = [Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]', False)]
  
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_fuzzy_search_3(self):
         """
@@ -77,9 +71,7 @@ class TestDatabase(unittest.TestCase):
             Card('Spell08NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru"]', False)
             ]
 
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_fuzzy_search_multicard_1(self):
         """
@@ -98,9 +90,7 @@ class TestDatabase(unittest.TestCase):
             Card('Spell08NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru"]', False)
             ]
 
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_location_search(self):
         """
@@ -109,9 +99,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('Altar of Death')
         expected_results = [Location('AltarOfDeath', 'Altar of Death', 'After you play a card here, destroy it to get +2 Energy next turn.', 'Rare', True, 'https://marvelsnap.pro/cards/altarofdeath')]
 
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
     
     def test_card_partial_search(self):
         """
@@ -121,9 +109,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('hope')
         expected_results = [Card('HopeSummers', 'Hope Summers', '3', '3', 'After you play a card here, you get +2 Energy next turn.', False, 'https://marvelsnap.pro/cards/hopesummers', False, '[]', False)]
         
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_card_partial_search_not_found(self):
         """
@@ -134,9 +120,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('m')
         expected_results = []
 
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_card_partial_search_not_found(self):
         """
@@ -146,9 +130,7 @@ class TestDatabase(unittest.TestCase):
         result = self.database.search('Mobius')
         expected_results = [Card('MobiusMMobius', 'Mobius M. Mobius', '3', '3', '<b>Ongoing:</b> Your Costs can\'t be increased. Your opponent\'s Costs can\'t be reduced.', True, 'https://marvelsnap.pro/cards/mobiusmmobius', False, '[]', False)]
 
-        self.assertEqual(len(expected_results), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_results[i], result[i])
+        self.assertEqual(expected_results, result)
 
     def test_resolve_tokens(self):
         """
@@ -162,9 +144,7 @@ class TestDatabase(unittest.TestCase):
             Card('Thanos', 'Thanos', '6', '10', 'At the start of the game, shuffle the six Infinity Stones into your deck.', True, 'https://marvelsnap.pro/cards/thanos', False, '["SpaceStone", "RealityStone", "TimeStone", "MindStone", "PowerStone", "SoulStone"]', False)
         ]
 
-        self.assertEqual(len(expected_result), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_result[i], result[i])
+        self.assertEqual(expected_result, result)
 
     def test_insert_tokens(self):
         """
@@ -184,9 +164,7 @@ class TestDatabase(unittest.TestCase):
             Card('SoulStone', 'Soul Stone', '1', '1', '<b>Ongoing:</b> Enemy cards here have -1 Power.', True, 'https://marvelsnap.pro/cards/soulstone', True, '["Thanos"]', True)
         ]
 
-        self.assertEqual(len(expected_result), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_result[i], result[i])
+        self.assertEqual(expected_result, result)
     
     def test_match_nico_duplication(self):
         """
@@ -210,9 +188,44 @@ class TestDatabase(unittest.TestCase):
             Card('Spell08NicoMinoru', 'Nico Minoru', '1', '2', '<b>On Reveal:</b> After you play your next card, double this card\'s Power.', True, 'https://marvelsnap.pro/cards/spell07nicominoru', True, '["Spell01NicoMinoru", "Spell02NicoMinoru", "Spell03NicoMinoru", "Spell04NicoMinoru", "Spell05NicoMinoru", "Spell06NicoMinoru"]', True)
             ]
         
-        self.assertEqual(len(expected_results), len(results))
-        for i in range(0, len(results)):
-            self.assertEqual(expected_results[i], results[i])
+        self.assertEqual(expected_results, results)
+    
+    def test_not_searchable_card(self):
+        """
+        Verify that a card marked as not searchable is not searchable
+        """
+        cards = self.database.search('Abomination')
+
+        expected_results = [
+            Card('Abomination', 'Abomination', '5', '9', '<i>"Foolish rabble! You are beneath me!"</i>', True, 'https://marvelsnap.pro/cards/abomination', False, '[]', False)
+        ]
+
+        self.assertEqual(expected_results, cards)
+    
+    def test_search_evolved(self):
+        """
+        Test that a search for High Evo will return the evolved cards as well as
+        the updated "Evolved" names to differentiate them from the standard
+        non-evolved cards
+        """
+        cards = self.database.search('High Evolutionary')
+        cards = utils.remove_duplicate_cards(cards)
+        cards = utils.resolve_tokens_to_base(self.database, cards)
+        cards = utils.remove_duplicate_cards(cards)
+        results = utils.insert_tokens_from_cards(self.database, cards)
+
+        expected_results = [
+            Card('HighEvolutionary', 'High Evolutionary', '4', '4', 'At the start of the game, unlock the potential of your cards with no abilities.', True, 'https://marvelsnap.pro/cards/highevolutionary', False, '["EvolvedWasp","EvolvedMistyKnight","EvolvedShocker","EvolvedCyclops","EvolvedTheThing","EvolvedAbomination","EvolvedHulk"]', False),
+            Card('EvolvedWasp', 'Evolved Wasp', '0', '1', '<color=#fad728><b>On Reveal:</b> Afflict an enemy card here with -1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedwasp', True, '[]', True),
+            Card('EvolvedMistyKnight', 'Evolved Misty Knight', '1', '2', '<color=#fad728>When you end a turn with unspent Energy, give one of your other cards +1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedmistyknight', True, '[]', True),
+            Card('EvolvedShocker', 'Evolved Shocker', '2', '3', '<color=#fad728><b>On Reveal:</b> Give the leftmost card in your hand -1 Cost.</color>', True, 'https://marvelsnap.pro/cards/evolvedshocker', True, '[]', True),
+            Card('EvolvedCyclops', 'Evolved Cyclops', '3', '4', '<color=#fad728>When you end a turn with unspent Energy, afflict 2 enemy cards here with -1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedcyclops', True, '[]', True),
+            Card('EvolvedTheThing', 'Evolved The Thing', '4', '6', '<color=#fad728><b>On Reveal:</b> Afflict 3 enemy cards here with -1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedthething', True, '[]', True),
+            Card('EvolvedAbomination', 'Evolved Abomination', '5', '9', '<color=#fad728>Costs 1 less for each enemy card in play that\'s afflicted with negative Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedabomination', True, '[]', True),
+            Card('EvolvedHulk', 'Evolved Hulk', '6', '12', '<color=#fad728>When you end a turn with unspent Energy, +2 Power. <i>(if in hand or in play)</i></color>', True, 'https://marvelsnap.pro/cards/evolvedhulk', True, '[]', True)
+        ]
+
+        self.assertEqual(expected_results, results)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -216,13 +216,13 @@ class TestDatabase(unittest.TestCase):
 
         expected_results = [
             Card('HighEvolutionary', 'High Evolutionary', '4', '4', 'At the start of the game, unlock the potential of your cards with no abilities.', True, 'https://marvelsnap.pro/cards/highevolutionary', False, '["EvolvedWasp","EvolvedMistyKnight","EvolvedShocker","EvolvedCyclops","EvolvedTheThing","EvolvedAbomination","EvolvedHulk"]', False),
-            Card('EvolvedWasp', 'Evolved Wasp', '0', '1', '<color=#fad728><b>On Reveal:</b> Afflict an enemy card here with -1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedwasp', True, '[]', True),
-            Card('EvolvedMistyKnight', 'Evolved Misty Knight', '1', '2', '<color=#fad728>When you end a turn with unspent Energy, give one of your other cards +1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedmistyknight', True, '[]', True),
-            Card('EvolvedShocker', 'Evolved Shocker', '2', '3', '<color=#fad728><b>On Reveal:</b> Give the leftmost card in your hand -1 Cost.</color>', True, 'https://marvelsnap.pro/cards/evolvedshocker', True, '[]', True),
-            Card('EvolvedCyclops', 'Evolved Cyclops', '3', '4', '<color=#fad728>When you end a turn with unspent Energy, afflict 2 enemy cards here with -1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedcyclops', True, '[]', True),
-            Card('EvolvedTheThing', 'Evolved The Thing', '4', '6', '<color=#fad728><b>On Reveal:</b> Afflict 3 enemy cards here with -1 Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedthething', True, '[]', True),
-            Card('EvolvedAbomination', 'Evolved Abomination', '5', '9', '<color=#fad728>Costs 1 less for each enemy card in play that\'s afflicted with negative Power.</color>', True, 'https://marvelsnap.pro/cards/evolvedabomination', True, '[]', True),
-            Card('EvolvedHulk', 'Evolved Hulk', '6', '12', '<color=#fad728>When you end a turn with unspent Energy, +2 Power. <i>(if in hand or in play)</i></color>', True, 'https://marvelsnap.pro/cards/evolvedhulk', True, '[]', True)
+            Card('EvolvedWasp', 'Evolved Wasp', '0', '1', '<color=#fad728><b>On Reveal:</b> Afflict an enemy card here with -1 Power.</color>', True, None, True, '[]', True),
+            Card('EvolvedMistyKnight', 'Evolved Misty Knight', '1', '2', '<color=#fad728>When you end a turn with unspent Energy, give one of your other cards +1 Power.</color>', True, None, True, '[]', True),
+            Card('EvolvedShocker', 'Evolved Shocker', '2', '3', '<color=#fad728><b>On Reveal:</b> Give the leftmost card in your hand -1 Cost.</color>', True, None, True, '[]', True),
+            Card('EvolvedCyclops', 'Evolved Cyclops', '3', '4', '<color=#fad728>When you end a turn with unspent Energy, afflict 2 enemy cards here with -1 Power.</color>', True, None, True, '[]', True),
+            Card('EvolvedTheThing', 'Evolved The Thing', '4', '6', '<color=#fad728><b>On Reveal:</b> Afflict 3 enemy cards here with -1 Power.</color>', True, None, True, '[]', True),
+            Card('EvolvedAbomination', 'Evolved Abomination', '5', '9', '<color=#fad728>Costs 1 less for each enemy card in play that\'s afflicted with negative Power.</color>', True, None, True, '[]', True),
+            Card('EvolvedHulk', 'Evolved Hulk', '6', '12', '<color=#fad728>When you end a turn with unspent Energy, +2 Power. <i>(if in hand or in play)</i></color>', True, None, True, '[]', True)
         ]
 
         self.assertEqual(expected_results, results)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,9 +36,7 @@ class TestCommentParser(unittest.TestCase):
             Card('Wolverine', 'Wolverine', '2', '2', 'When this is discarded or destroyed, regenerate it with +2 Power at a random location.', True, 'https://marvelsnap.pro/cards/wolverine', False, '[]', False)
         ]
 
-        self.assertEqual(len(expected_result), len(result))
-        for i in range(0, len(result)):
-            self.assertEqual(expected_result[i], result[i])
+        self.assertEqual(expected_result, result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There are a few things wrapped into this pull request:
1. Closes #9, a hardcoded list of Evolved cards specifically removes the URLs from the output
2. Closes #6, removes the invalid formatting for evolved cards
3. Adds the "Evolved" word to the title of the evolved cards
4. Adds word to the Snowguard summons name
5. Allows some cards to become unsearchable
6. Updating unit test to remove pointless loop