### PR TITLE
Fix Base/Summon Order

### DIFF
--- a/snap_bot/database/card.py
+++ b/snap_bot/database/card.py
@@ -12,6 +12,7 @@ class Card(Entry):
         self.formatted_ability = ''
         self.summoned = summoned
         self.searchable = True
+        self.matchable = True
 
     def to_constructor_string(self):
         """

--- a/snap_bot/database/database.py
+++ b/snap_bot/database/database.py
@@ -32,12 +32,16 @@ class Database:
         if card.def_id in patches:
             if 'searchable' in patches[card.def_id]:
                 card.searchable = patches[card.def_id]['searchable']
+            if 'matchable' in patches[card.def_id]:
+                card.matchable = patches[card.def_id]['matchable']
             if 'name' in patches[card.def_id]:
                 card.name = patches[card.def_id]['name']
             if 'url' in patches[card.def_id]:
                 card.url = patches[card.def_id]['url']
             if 'is_Token' in patches[card.def_id]:
                 card.is_token = patches[card.def_id]['is_Token']
+            if 'connected_cards' in patches[card.def_id]:
+                card.connected_cards = json.loads(patches[card.def_id]['connected_cards'])
 
     def update_card_database_marvelsnappro(self):
         """
@@ -181,7 +185,7 @@ class Database:
         # Always check cards first, so that the base card will be at the top of
         # the response
         for card in self.cards:
-            if card.def_id == query:
+            if card.def_id == query and card.matchable:
                 return card
         
         for card in self.locations:

--- a/snap_bot/database/database.py
+++ b/snap_bot/database/database.py
@@ -1,4 +1,6 @@
 import requests
+import json
+from .patches import patches
 from wells.utils import retry
 
 from . import Card
@@ -8,7 +10,6 @@ class Database:
     def __init__(self, max_fuzzy_distance: int = 2, exact_match_threshold: int = 3):
         self.cards = []
         self.locations = []
-        self.summons = []
         self.max_fuzzy_distance = max_fuzzy_distance
         self.exact_match_threshold = exact_match_threshold
 
@@ -27,61 +28,16 @@ class Database:
         
         return response
 
-    def update_card_searchability(self, card):
-        """
-        Update the searchability of a given card based on criteria for that card
-        """
-
-        # The "Evolved" cards may be pulled in as tokens for High Evo, but as a
-        # general rule I don't think they should be generally searchable as it
-        # kind of clutters the search results for the standard card.
-        if card.def_id.startswith('Evolved'):
-            card.searchable = False
-        else:
-            card.searchable = True
-    
-    def update_card_name(self, card):
-        """
-        Update the names of cards to be a little more descriptive. This could be
-        maybe moved into a lookup file/table at some point
-        """
-
-        if card.def_id == 'EvolvedAbomination':
-            card.name = 'Evolved Abomination'
-        elif card.def_id == 'EvolvedCyclops':
-            card.name = 'Evolved Cyclops'
-        elif card.def_id == 'EvolvedHulk':
-            card.name = 'Evolved Hulk'
-        elif card.def_id == 'EvolvedMistyKnight':
-            card.name = 'Evolved Misty Knight'
-        elif card.def_id == 'EvolvedShocker':
-            card.name = 'Evolved Shocker'
-        elif card.def_id == 'EvolvedTheThing':
-            card.name = 'Evolved The Thing'
-        elif card.def_id == 'EvolvedWasp':
-            card.name = 'Evolved Wasp'
-        elif card.def_id == 'SnowguardBear':
-            card.name = 'Snowguard Bear'
-        elif card.def_id == 'SnowguardHawk':
-            card.name = 'Snowguard Hawk'
-    
-    def update_card_url(self, card):
-        """
-        Update or remove the URL if it is a card we know has a non-funcitoning URL.
-        It would technically be possible to ping each URL and verify that they
-        are valid, but I do not want to put any unneeded stress on the server
-        I'm obtaining the card lookup information from. So instead, I'm just
-        going to hardcode a list of cards to remove the URL from.
-        """
-        
-        if card.def_id == 'EvolvedAbomination' or \
-           card.def_id == 'EvolvedCyclops' or \
-           card.def_id == 'EvolvedHulk' or \
-           card.def_id == 'EvolvedMistyKnight' or \
-           card.def_id == 'EvolvedShocker' or \
-           card.def_id == 'EvolvedTheThing' or \
-           card.def_id == 'EvolvedWasp':
-            card.url = None
+    def patch_card(self, card):
+        if card.def_id in patches:
+            if 'searchable' in patches[card.def_id]:
+                card.searchable = patches[card.def_id]['searchable']
+            if 'name' in patches[card.def_id]:
+                card.name = patches[card.def_id]['name']
+            if 'url' in patches[card.def_id]:
+                card.url = patches[card.def_id]['url']
+            if 'is_Token' in patches[card.def_id]:
+                card.is_token = patches[card.def_id]['is_Token']
 
     def update_card_database_marvelsnappro(self):
         """
@@ -95,7 +51,6 @@ class Database:
         jdata = data.json()
 
         self.cards = []
-        self.summons = []
         self.locations = []
         for card in jdata:
             def_id = jdata[card]['CardDefId']
@@ -115,38 +70,19 @@ class Database:
             if is_token == '0' and source == 'None':
                 released = False
 
-            if is_token == '1':
-                self.summons.append(Card(
-                    def_id = def_id, 
-                    name = name, 
-                    cost = cost, 
-                    power = power, 
-                    ability = ability, 
-                    released = released, 
-                    url = url, 
-                    is_token = True, 
-                    connected_cards = connected_cards, 
-                    summoned = False))
-                self.update_card_searchability(self.summons[-1])
-                self.update_card_name(self.summons[-1])
-                self.update_card_url(self.summons[-1])
-                self.summons[-1].format_ability_from_html()
-            else:
-                self.cards.append(Card(
-                    def_id = def_id, 
-                    name = name, 
-                    cost = cost, 
-                    power = power, 
-                    ability = ability, 
-                    released = released, 
-                    url = url, 
-                    is_token = False, 
-                    connected_cards = connected_cards, 
-                    summoned = False))
-                self.update_card_searchability(self.cards[-1])
-                self.update_card_name(self.cards[-1])
-                self.update_card_url(self.cards[-1])
-                self.cards[-1].format_ability_from_html()
+            self.cards.append(Card(
+                def_id = def_id, 
+                name = name, 
+                cost = cost, 
+                power = power, 
+                ability = ability, 
+                released = released, 
+                url = url, 
+                is_token = (True if is_token == '1' else False), 
+                connected_cards = connected_cards, 
+                summoned = False))
+            self.patch_card(self.cards[-1])
+            self.cards[-1].format_ability_from_html()
 
         data = self.download_url(api_location_url)
         jdata = data.json()
@@ -207,19 +143,7 @@ class Database:
                 best_match = [card]
             elif next_match_score == best_match_score:
                 best_match.append(card)
-        
-        # Next check the Summons so that the summon will be listed second after
-        # the card
-        for summon in self.summons:
-            if not summon.searchable:
-                continue
-            next_match_score = summon.test_distance_splits(query)
-            if next_match_score < best_match_score:
-                best_match_score = next_match_score
-                best_match = [summon]
-            elif next_match_score == best_match_score:
-                best_match.append(summon)
-        
+
         for location in self.locations:
             next_match_score = location.test_distance_splits(query)
             if next_match_score < best_match_score:
@@ -257,10 +181,6 @@ class Database:
         # Always check cards first, so that the base card will be at the top of
         # the response
         for card in self.cards:
-            if card.def_id == query:
-                return card
-        
-        for card in self.summons:
             if card.def_id == query:
                 return card
         

--- a/snap_bot/database/patches.py
+++ b/snap_bot/database/patches.py
@@ -1,0 +1,46 @@
+patches = {
+    'EvolvedAbomination': {
+        'searchable': False, 
+        'name': 'Evolved Abomination', 
+        'url': None
+    }, 
+    'EvolvedCyclops': {
+        'searchable': False, 
+        'name': 'Evolved Cyclops', 
+        'url': None
+    }, 
+    'EvolvedHulk': {
+        'searchable': False, 
+        'name': 'Evolved Hulk', 
+        'url': None
+    }, 
+    'EvolvedMistyKnight': {
+        'searchable': False, 
+        'name': 'Evolved Misty Knight', 
+        'url': None
+    }, 
+    'EvolvedShocker': {
+        'searchable': False, 
+        'name': 'Evolved Shocker', 
+        'url': None
+    }, 
+    'EvolvedTheThing': {
+        'searchable': False, 
+        'name': 'Evolved The Thing', 
+        'url': None
+    }, 
+    'EvolvedWasp': {
+        'searchable': False, 
+        'name': 'Evolved Wasp', 
+        'url': None
+    }, 
+    'EbonyBlade': {
+        'is_Token': True
+    }, 
+    'SnowguardBear': {
+        'name': 'Snowguard Bear'
+    }, 
+    'SnowguardHawk': {
+        'name': 'Snowguard Hawk'
+    }
+}

--- a/snap_bot/database/patches.py
+++ b/snap_bot/database/patches.py
@@ -37,10 +37,30 @@ patches = {
     'EbonyBlade': {
         'is_Token': True
     }, 
+    'MuramasaShard': {
+        'is_Token': True
+    },
+    'MysterioIllusion': {
+        'is_Token': True
+    },
+    'Stormbreaker': {
+        'is_Token': True
+    },
+    'Pig': {
+        'is_Token': True
+    },
     'SnowguardBear': {
         'name': 'Snowguard Bear'
     }, 
     'SnowguardHawk': {
         'name': 'Snowguard Hawk'
+    },
+    'UncleBen': {
+        'searchable': False,
+        'matchable': False
+    },
+    'WidowsBite': {
+        'connected_cards': '["BlackWidow"]',
+        'is_Token': True
     }
 }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -226,6 +226,28 @@ class TestDatabase(unittest.TestCase):
         ]
 
         self.assertEqual(expected_results, results)
+    
+    def test_ebony_order(self):
+        """
+        I discovered a bug where if you search for "Ebody Blade" or other similar
+        cards, it will return return looking like that is the base card and the
+        card that may summon it is the summon card. This tests to ensure that
+        that situation does not occur.
+        """
+
+        cards = self.database.search('Ebony Blade')
+        cards = utils.remove_duplicate_cards(cards)
+        cards = utils.resolve_tokens_to_base(self.database, cards)
+        cards = utils.remove_duplicate_cards(cards)
+        results = utils.insert_tokens_from_cards(self.database, cards)
+
+        expected_results = [
+            Card('BlackKnight', 'Black Knight', '1', '2', 'After you discard a card, add the Ebony Blade to your hand with that card\'s Power. <i>(once per game)</i>', True, 'https://marvelsnap.pro/cards/blackknight', False, '["EbonyBlade"]', True),
+            Card('EbonyBlade', 'Ebony Blade', '4', '0', '<b>Ongoing:</b> Can\'t be destroyed and its Power can\'t be reduced.', False, 'https://marvelsnap.pro/cards/ebonyblade', True, '["BlackKnight"]', False)
+        ]
+
+        self.assertEqual(expected_results, results)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -247,7 +247,46 @@ class TestDatabase(unittest.TestCase):
         ]
 
         self.assertEqual(expected_results, results)
+    
+    def test_uncle_ben(self):
+        """
+        As of this time, Spider-Man links to Uncle Ben, but Uncle Ben isn't
+        in the game at all and does not appear to have a point where he will
+        be added. So since I'm pulling in tokens for cards, this provides a
+        confusing output. Thus I've disabled Uncle Ben from being matched and
+        will test here to ensure that he is not found.
+        """
 
+        cards = self.database.search('Spider-Man')
+        cards = utils.remove_duplicate_cards(cards)
+        cards = utils.resolve_tokens_to_base(self.database, cards)
+        cards = utils.remove_duplicate_cards(cards)
+        results = utils.insert_tokens_from_cards(self.database, cards)
+
+        expected_results = [
+            Card('SpiderMan', 'Spider-Man', '3', '5', '<b>On Reveal:</b> Move to another location and pull an enemy card from here to there.', True, 'https://marvelsnap.pro/cards/spiderman', False, '["UncleBen"]', False)
+        ]
+
+        self.assertEqual(expected_results, results)
+    
+    def test_widows_bite(self):
+        """
+        The Widow's Bite card is not reporting as being connected to Black Widow
+        so this tests our manual data fix works.
+        """
+
+        cards = self.database.search('Widows Bite')
+        cards = utils.remove_duplicate_cards(cards)
+        cards = utils.resolve_tokens_to_base(self.database, cards)
+        cards = utils.remove_duplicate_cards(cards)
+        results = utils.insert_tokens_from_cards(self.database, cards)
+
+        expected_results = [
+            Card('BlackWidow', 'Black Widow', '3', '3', '<b>On Reveal:</b> Add a Widow\'s Bite to your opponent\'s hand.', True, 'https://marvelsnap.pro/cards/blackwidow', False, '["WidowsBite"]', False),
+            Card('WidowsBite', 'Widow\'s Bite', '0', '-1', 'While this is in your hand, you can\'t draw cards.', False, 'https://marvelsnap.pro/cards/widowsbite', True, '["BlackWidow"]', True)
+        ]
+
+        self.assertEqual(expected_results, results)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It looks like the data source that is being used (marvelsnap.pro) is not being consistent on when `is_Token` is or isn't being set. So it resulted in some instances where a card would be linked together, but would not indicate which is the token and which is the base card, causing output that looked like the summon summoned the base card.

In addition to the above, I found some other inconsistencies such as `Widow's Bite` did not list as connected to `Black Widow`, causing it to appear as a standalone card rather thing pulling in that it was summoned.

Instead of continuing with a hardcoded list of corrected issues, I've created a `patches.py` which contains a configuration file for all patches that I'm applying to the data source after reading it. This is to correct any of these inconsistencies that I'm seeing. Now, patching a data source like this isn't ideal, but I'm uncertain how to resolve this without doing something like that. So I've read over the data source and tried to find all instances that required a similar patch and apply them here.

One additional comment, I noticed that `Spider-Man` links to `Uncle Ben`, listing `Uncle Ben` as a token of the card. There are two strange things with this. Firstly, I'd expect the opposite direction for a card/token. Secondly, `Uncle Ben` hasn't been released. So instead of outputting like that, I'm just removing `Uncle Ben` from the results.

One thought here, instead of removing `Uncle Ben`, we could have a data patch that unlinks `Spider-Man` from it, to still allow it to be searched? I think it's a bit less important at this point, so I'll just keep `Uncle Ben` removed for the moment.