### PR TITLE
Ignore old Marvel Snap bot

### DIFF
--- a/snap_bot/main.py
+++ b/snap_bot/main.py
@@ -206,7 +206,8 @@ if __name__ == '__main__':
 
                 # Prevent replying to my own comments, if the author of the
                 # comment is the bot itself, then simply ignore the comment
-                if reddit_connect.get_my_username() == comment.author:
+                if reddit_connect.get_my_username() == comment.author or \
+                    'MarvelSnapCardBot' == comment.author:
                     continue
 
                 # Parse the comment and fetch the card names from it
@@ -254,7 +255,8 @@ if __name__ == '__main__':
                     # our username is not in a reply to this comment. This is to
                     # prevent us from replying to the same comment multiple times
                     authors = reddit_connect.get_comment_reply_author_names(comment.id)
-                    if reddit_connect.get_my_username() not in authors:
+                    if reddit_connect.get_my_username() not in authors and \
+                        'MarvelSnapCardBot' not in authors:
                         logging.info('Submitting reply')
                         logging.debug(response)
                         if dry_run == False:


### PR DESCRIPTION
Since I have been unable to contact the original bot creator as the /u/MarvelSnapCardBot account does not allow direct messages and I do not see anywhere on that bot account where the owner claimed ownership. Nor do I see any github repositories listing that bot account. I have added an ignore into this bot so that it will ignore comments created by /u/MarvelSnapCardBot as well as when it checks to see if it should reply to a comment, it will skip replying to it if /u/MarvelSnapCardBot has already replied.

This is just a bit of insurance in case the /u/MarvelSnapCardBot comes back online at some point, I don't want for both that bot and this bot to double-comment on peoples comments. So instead, if /u/MarvelSnapCardBot has already commented, this bot will ignore the comment and move on from it.

This does not solve the issue where this bot acts faster than /u/MarvelSnapCardBot. If that is the case, then this bot will reply to the comment, then the /u/MarvelSnapCardBot bot will reply, producing a double-comment situation. If that occurs, I will see if I am able to contact the owner of /u/MarvelSnapCardBot and working something out.