### PR TITLE
Prefer exact card match

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -17,6 +17,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    needs: [test]
     permissions:
       packages: write
     steps:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -18,6 +18,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    needs: [test]
     permissions:
       packages: write
     steps:

--- a/snap_bot/database/database.py
+++ b/snap_bot/database/database.py
@@ -133,28 +133,56 @@ class Database:
         Thanos as a base card will later pull in all the summons, so the output
         that the user will eventually see is Thanos, followed by all stones.
         """
-        best_match_score = 99999
+        best_match_score = 9999
         best_match = []
 
-        # Always check cards first, so that the base card will be at the top of
-        # the response
         for card in self.cards:
             if not card.searchable:
                 continue
-            next_match_score = card.test_distance_splits(query)
-            if next_match_score < best_match_score:
-                best_match_score = next_match_score
+
+            next_base_score = card.test_distance(query)
+            if next_base_score < best_match_score:
+                best_match_score = next_base_score
                 best_match = [card]
-            elif next_match_score == best_match_score:
+            elif next_base_score == best_match_score:
                 best_match.append(card)
 
         for location in self.locations:
-            next_match_score = location.test_distance_splits(query)
-            if next_match_score < best_match_score:
-                best_match_score = next_match_score
+            # if not location.searchable:
+            #     continue
+            
+            next_base_score = location.test_distance(query)
+            if next_base_score < best_match_score:
+                best_match_score = next_base_score
                 best_match = [location]
-            elif next_match_score == best_match_score:
+            elif next_base_score == best_match_score:
                 best_match.append(location)
+
+        if best_match_score != 0:
+
+            for card in self.cards:
+                if not card.searchable:
+                    continue
+                
+                next_split_score = card.test_distance_splits(query)
+                if next_split_score < best_match_score:
+                    best_match_score = next_split_score
+                    best_match = [card]
+                elif next_split_score == best_match_score:
+                    if card not in best_match:
+                        best_match.append(card)
+
+            for location in self.locations:
+                # if not location.searchable:
+                #     continue
+                
+                next_split_score = location.test_distance_splits(query)
+                if next_split_score < best_match_score:
+                    best_match_score = next_split_score
+                    best_match = [location]
+                elif next_split_score == best_match_score:
+                    if location not in best_match:
+                        best_match.append(location)
 
         # Consolidate the resulting searches together and return the output.
         # We have a few cases here:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -287,6 +287,22 @@ class TestDatabase(unittest.TestCase):
         ]
 
         self.assertEqual(expected_results, results)
+    
+    def test_exact_and_split_match(self):
+        """
+        We want to wait an exact match such as [[Death]] higher than a partial or
+        split match such as "Alter of Death" (since it contains "Death" in the
+        name). This test ensures that a search for "Death" returns just "Death"
+        and not "Alter of Death"
+        """
+
+        results = self.database.search('Death')
+
+        expected_results = [
+            Card('Death', 'Death', '8', '12', 'Costs 1 less for each card destroyed this game.', True, 'https://marvelsnap.pro/cards/death', False, '[]', False)
+        ]
+
+        self.assertEqual(expected_results, results)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This closes #18, when viewing matching results, I found that a user could search for `[[Death]]` but it would return results for:
* Death
* Death's Domain
* Alter of Death

While I can see *why* these matched, since "Death" was included in all of them, it does provide a slightly misleading result, since it is pretty obvious that a user would like to see the card "Death" and not the other locations.

To resolve this, I've updated the matching to prefer an exact match to the full text first. If no exact match is found, then it will pull in the other matches. This will allow someone searching for `[[Death]]` to match to exactly the card "Death" and not the other partial-matches.

If the original search is not spelled correctly, for example if it is `[[Daeth]]`, then this will bypass the logic above and will pull in partial matches.

Additionally, this updates the CI/CD pipeline to require test to be completed before it builds the Docker container.