### PR TITLE
Fix: Add URL parameter for linking back to the original comment in GitHub links

### DIFF
--- a/snap_bot/comments/comment.py
+++ b/snap_bot/comments/comment.py
@@ -3,4 +3,7 @@ class Comment:
         self.id = id
         self.author = author
         self.body = body
-        self.url = url
+        self.url = f"{url}?from_comment={id}"
+
+    def get_github_url(self) -> str:
+        return self.url


### PR DESCRIPTION
This change modifies the `Comment` class to include a URL parameter that references the original comment ID. This allows users to navigate back to the original comment from the linked GitHub post, making debugging and reference tracking easier.

**Changes Made:**
- Updated the `url` attribute in the `__init__` method to append a query parameter `from_comment={id}`.
- Added a new method `get_github_url` that returns the modified URL.