### PR TITLE
Add query parameter to GitHub links for traceability

### DIFF
--- a/snap_bot/comments/comment_parser.py
+++ b/snap_bot/comments/comment_parser.py
@@ -9,7 +9,18 @@ class CommentParser:
     def parse(self):
         """
         Use a simple regex pattern to find all [[xxx]] entries in the comment
-        body, returning a list of the entries found
+        body, returning a list of the entries found. Also, modify any GitHub URLs
+        to include a reference back to the original comment.
         """
-        match = re.findall(r'\\?\\?\[\\?\\?\[([^]\\]+)\\?\\?\]\\?\\?\]', self.comment.body)
-        return match
+        matches = re.findall(r'\\?\\?\[\\?\\?\[([^]\\]+)\\?\\?\]\\?\\?\]', self.comment.body)
+        
+        # Modify GitHub URLs to include a reference back to the original comment
+        modified_matches = []
+        for match in matches:
+            if 'github.com' in match and '?ref=' not in match:
+                modified_match = f"{match}?ref={self.comment.url}"
+                modified_matches.append(modified_match)
+            else:
+                modified_matches.append(match)
+        
+        return modified_matches

--- a/snap_bot/reddit_connect/reddit_connet.py
+++ b/snap_bot/reddit_connect/reddit_connet.py
@@ -38,11 +38,11 @@ class RedditConnect:
         Initialize the Reddit connection using the supplied details
         """
         self.reddit = praw.Reddit(
-            client_id = client_id,
-            client_secret = client_secret,
-            username = username,
-            password = password,
-            user_agent = user_agent)
+            client_id=client_id,
+            client_secret=client_secret,
+            username=username,
+            password=password,
+            user_agent=user_agent)
 
         self.subreddit = self.reddit.subreddit(self.subreddit_name)
     
@@ -61,7 +61,9 @@ class RedditConnect:
             count += 1
             if comment.id not in self.seen_comments:
                 self.seen_comments.append(comment.id)
-                comments.append(Comment(comment.id, comment.author.name, comment.body, 'https://reddit.com' + comment.permalink))
+                # Add a query parameter to link back to the original comment
+                github_url_with_comment = f"https://github.com/user/repo/issues/1?comment_id={comment.id}"
+                comments.append(Comment(comment.id, comment.author.name, comment.body, 'https://reddit.com' + comment.permalink, github_url_with_comment))
         
         # To prevent this list from simply growing to an unmanagable size, we
         # will simply remove old entries when it has more than 150, since the
@@ -96,3 +98,6 @@ class RedditConnect:
         Enable read-only mode, useful for dry run
         """
         self.reddit.read_only = True
+```
+
+Note: The `github_url_with_comment` is a placeholder URL. You should replace `"https://github.com/user/repo/issues/1?comment_id={comment.id}"` with the actual GitHub repository and issue path you are working with.


### PR DESCRIPTION
When clicking the GitHub link in a comment, this change adds a URL parameter that references back to the original comment. This makes debugging easier as we can simply go back to the original comment.

Changes made:
- Modified `comment_parser.py` to append a reference to the original comment for any GitHub URLs found in comments.
- Updated `reddit_connect/reddit_connet.py` to include a query parameter linking back to the original Reddit comment in the GitHub URL.